### PR TITLE
Add question bank and simple review mode

### DIFF
--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Note;
+use App\Models\Question;
+use Illuminate\Http\Request;
+
+class QuestionController extends Controller
+{
+    /**
+     * 題庫列表
+     */
+    public function index()
+    {
+        $questions = Question::with('note')
+            ->where('user_id', session('supabase_user.id'))
+            ->latest()
+            ->get();
+
+        return view('questions.index', compact('questions'));
+    }
+
+    /**
+     * 顯示新增題目頁
+     */
+    public function create()
+    {
+        $notes = Note::where('user_id', session('supabase_user.id'))
+            ->latest()
+            ->get();
+
+        return view('questions.create', compact('notes'));
+    }
+
+    /**
+     * 新增題目
+     */
+    public function store(Request $request)
+    {
+        $data = $request->only([
+            'note_id',
+            'question_type',
+            'question_text',
+            'answer_text',
+            'explanation',
+        ]);
+
+        $note = Note::where('id', $data['note_id'] ?? null)
+            ->where('user_id', session('supabase_user.id'))
+            ->first();
+
+        if (!$note) {
+            abort(403);
+        }
+
+        $data['user_id'] = session('supabase_user.id');
+        $data['review_level'] = $this->sanitizeReviewLevel($request->input('review_level'));
+        $data['choices'] = $this->normalizeChoices(
+            $request->input('choices'),
+            $data['question_type'] ?? null
+        );
+
+        Question::create($data);
+
+        return redirect()->route('questions.index');
+    }
+
+    /**
+     * 顯示編輯題目頁
+     */
+    public function edit(Question $question)
+    {
+        if ($question->user_id !== session('supabase_user.id')) {
+            abort(403);
+        }
+
+        $notes = Note::where('user_id', session('supabase_user.id'))
+            ->latest()
+            ->get();
+
+        return view('questions.edit', compact('question', 'notes'));
+    }
+
+    /**
+     * 更新題目
+     */
+    public function update(Request $request, Question $question)
+    {
+        if ($question->user_id !== session('supabase_user.id')) {
+            abort(403);
+        }
+
+        $data = $request->only([
+            'note_id',
+            'question_type',
+            'question_text',
+            'answer_text',
+            'explanation',
+        ]);
+
+        $note = Note::where('id', $data['note_id'] ?? null)
+            ->where('user_id', session('supabase_user.id'))
+            ->first();
+
+        if (!$note) {
+            abort(403);
+        }
+
+        $data['review_level'] = $this->sanitizeReviewLevel($request->input('review_level'));
+        $data['choices'] = $this->normalizeChoices(
+            $request->input('choices'),
+            $data['question_type'] ?? null
+        );
+
+        $question->update($data);
+
+        return redirect()->route('questions.index');
+    }
+
+    /**
+     * 刪除題目
+     */
+    public function destroy(Question $question)
+    {
+        if ($question->user_id !== session('supabase_user.id')) {
+            abort(403);
+        }
+
+        $question->delete();
+
+        return redirect()
+            ->route('questions.index')
+            ->with('success', '題目已刪除');
+    }
+
+    private function normalizeChoices(?string $choicesInput, ?string $questionType): ?array
+    {
+        if ($questionType !== 'choice') {
+            return null;
+        }
+
+        $choices = collect(preg_split('/\r\n|\r|\n/', $choicesInput ?? ''))
+            ->map(fn ($choice) => trim($choice))
+            ->filter()
+            ->values()
+            ->all();
+
+        return $choices ?: null;
+    }
+
+    private function sanitizeReviewLevel($level): int
+    {
+        $level = (int) $level;
+
+        if ($level < 1 || $level > 5) {
+            return 3;
+        }
+
+        return $level;
+    }
+}

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Question;
+
+class ReviewController extends Controller
+{
+    /**
+     * 顯示單題複習
+     */
+    public function show()
+    {
+        $question = Question::with('note')
+            ->where('user_id', session('supabase_user.id'))
+            ->inRandomOrder()
+            ->first();
+
+        return view('review.show', compact('question'));
+    }
+}

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Question extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'note_id',
+        'question_type',
+        'question_text',
+        'answer_text',
+        'choices',
+        'explanation',
+        'review_level',
+    ];
+
+    protected $casts = [
+        'choices' => 'array',
+    ];
+
+    public function note()
+    {
+        return $this->belongsTo(Note::class);
+    }
+}

--- a/database/migrations/2026_01_11_000000_create_questions_table.php
+++ b/database/migrations/2026_01_11_000000_create_questions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('questions', function (Blueprint $table) {
+            $table->id();
+            $table->string('user_id')->comment('Supabase user id / session user id');
+            $table->unsignedBigInteger('note_id');
+            $table->string('question_type');
+            $table->text('question_text');
+            $table->text('answer_text');
+            $table->json('choices')->nullable();
+            $table->text('explanation')->nullable();
+            $table->unsignedTinyInteger('review_level')->default(3);
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('note_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('questions');
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,21 +1,37 @@
 import './bootstrap';
+
 document.addEventListener('DOMContentLoaded', () => {
-  const typeSelect = document.querySelector('[name="note_type"]');
-  if (!typeSelect) return;
+  const noteTypeSelect = document.querySelector('[name="note_type"]');
+  if (noteTypeSelect) {
+    const blocks = document.querySelectorAll('[data-note-fields]');
 
-  const blocks = document.querySelectorAll('[data-note-fields]');
+    const toggleFields = () => {
+      const type = noteTypeSelect.value;
 
-  const toggleFields = () => {
-    const type = typeSelect.value;
+      blocks.forEach(block => {
+        block.style.display =
+          block.dataset.noteFields === type ? 'block' : 'none';
+      });
+    };
 
-    blocks.forEach(block => {
-      block.style.display =
-        block.dataset.noteFields === type ? 'block' : 'none';
-    });
-  };
+    noteTypeSelect.addEventListener('change', toggleFields);
+    toggleFields();
+  }
 
-  typeSelect.addEventListener('change', toggleFields);
+  const questionTypeSelect = document.querySelector('[name="question_type"]');
+  if (questionTypeSelect) {
+    const blocks = document.querySelectorAll('[data-question-fields]');
 
-  // 編輯頁 / 新增頁初始狀態
-  toggleFields();
+    const toggleQuestionFields = () => {
+      const type = questionTypeSelect.value;
+
+      blocks.forEach(block => {
+        block.style.display =
+          block.dataset.questionFields === type ? 'block' : 'none';
+      });
+    };
+
+    questionTypeSelect.addEventListener('change', toggleQuestionFields);
+    toggleQuestionFields();
+  }
 });

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,16 +15,28 @@
 
   {{-- 上方導覽（可先留空） --}}
 <nav class="navbar navbar-light bg-light mb-4">
-  <div class="container d-flex justify-content-between">
+  <div class="container d-flex justify-content-between align-items-center">
     <span class="navbar-brand mb-0 h1">JP-Note</span>
 
     @if (session()->has('supabase_user'))
-      <form method="POST" action="{{ route('logout') }}">
-        @csrf
-        <button type="submit" class="btn btn-outline-secondary btn-sm">
-          登出
-        </button>
-      </form>
+      <div class="d-flex align-items-center gap-2">
+        <a href="{{ route('notes.index') }}" class="btn btn-outline-secondary btn-sm">
+          我的筆記
+        </a>
+        <a href="{{ route('questions.index') }}" class="btn btn-outline-secondary btn-sm">
+          題庫
+        </a>
+        <a href="{{ route('review.show') }}" class="btn btn-outline-secondary btn-sm">
+          複習
+        </a>
+
+        <form method="POST" action="{{ route('logout') }}">
+          @csrf
+          <button type="submit" class="btn btn-outline-secondary btn-sm">
+            登出
+          </button>
+        </form>
+      </div>
     @endif
   </div>
 </nav>

--- a/resources/views/questions/create.blade.php
+++ b/resources/views/questions/create.blade.php
@@ -1,0 +1,78 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="card">
+    <div class="card-header">新增題目</div>
+
+    <div class="card-body">
+      @if ($notes->isEmpty())
+        <div class="alert alert-warning">
+          目前沒有可關聯的筆記，請先建立筆記。
+        </div>
+        <a href="{{ route('notes.create') }}" class="btn btn-primary">前往新增筆記</a>
+        <a href="{{ route('questions.index') }}" class="btn btn-secondary">返回</a>
+      @else
+        <form method="POST" action="{{ route('questions.store') }}">
+          @csrf
+
+          <div class="mb-3">
+            <label class="form-label">關聯筆記</label>
+            <select name="note_id" class="form-select">
+              @foreach ($notes as $note)
+                <option value="{{ $note->id }}">
+                  {{ $note->title }}（{{ $note->note_type }}）
+                </option>
+              @endforeach
+            </select>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">題型</label>
+            <select name="question_type" class="form-select">
+              <option value="recall">回想題</option>
+              <option value="fill">填空題</option>
+              <option value="choice">單選題</option>
+            </select>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">題目內容</label>
+            <textarea name="question_text" class="form-control" rows="3"></textarea>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">答案（必填）</label>
+            <textarea name="answer_text" class="form-control" rows="3"></textarea>
+          </div>
+
+          <div class="mb-3" data-question-fields="choice">
+            <label class="form-label">選項（每行一個）</label>
+            <textarea name="choices" class="form-control" rows="4"></textarea>
+            <div class="form-text">僅單選題需要填寫</div>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">補充解釋（選填）</label>
+            <textarea name="explanation" class="form-control" rows="3"></textarea>
+          </div>
+
+          <div class="mb-3">
+            <label class="form-label">主觀複習程度</label>
+            <select name="review_level" class="form-select">
+              <option value="1">1 = 很熟</option>
+              <option value="2">2 = 還可以</option>
+              <option value="3" selected>3 = 普通</option>
+              <option value="4">4 = 不熟</option>
+              <option value="5">5 = 很不熟</option>
+            </select>
+          </div>
+
+          <button class="btn btn-primary">儲存</button>
+          <a href="{{ route('questions.index') }}" class="btn btn-secondary">返回</a>
+        </form>
+      @endif
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/questions/edit.blade.php
+++ b/resources/views/questions/edit.blade.php
@@ -1,0 +1,71 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="card">
+    <div class="card-header">編輯題目</div>
+
+    <div class="card-body">
+      <form method="POST" action="{{ route('questions.update', $question) }}">
+        @csrf
+        @method('PUT')
+
+        <div class="mb-3">
+          <label class="form-label">關聯筆記</label>
+          <select name="note_id" class="form-select">
+            @foreach ($notes as $note)
+              <option value="{{ $note->id }}" @selected($note->id === $question->note_id)>
+                {{ $note->title }}（{{ $note->note_type }}）
+              </option>
+            @endforeach
+          </select>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">題型</label>
+          <select name="question_type" class="form-select">
+            <option value="recall" @selected($question->question_type === 'recall')>回想題</option>
+            <option value="fill" @selected($question->question_type === 'fill')>填空題</option>
+            <option value="choice" @selected($question->question_type === 'choice')>單選題</option>
+          </select>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">題目內容</label>
+          <textarea name="question_text" class="form-control" rows="3">{{ $question->question_text }}</textarea>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">答案（必填）</label>
+          <textarea name="answer_text" class="form-control" rows="3">{{ $question->answer_text }}</textarea>
+        </div>
+
+        <div class="mb-3" data-question-fields="choice">
+          <label class="form-label">選項（每行一個）</label>
+          <textarea name="choices" class="form-control" rows="4">{{ $question->choices ? implode("\n", $question->choices) : '' }}</textarea>
+          <div class="form-text">僅單選題需要填寫</div>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">補充解釋（選填）</label>
+          <textarea name="explanation" class="form-control" rows="3">{{ $question->explanation }}</textarea>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label">主觀複習程度</label>
+          <select name="review_level" class="form-select">
+            <option value="1" @selected($question->review_level === 1)>1 = 很熟</option>
+            <option value="2" @selected($question->review_level === 2)>2 = 還可以</option>
+            <option value="3" @selected($question->review_level === 3)>3 = 普通</option>
+            <option value="4" @selected($question->review_level === 4)>4 = 不熟</option>
+            <option value="5" @selected($question->review_level === 5)>5 = 很不熟</option>
+          </select>
+        </div>
+
+        <button class="btn btn-primary">更新</button>
+        <a href="{{ route('questions.index') }}" class="btn btn-secondary">返回</a>
+      </form>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/questions/index.blade.php
+++ b/resources/views/questions/index.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3>題庫管理</h3>
+    <a href="{{ route('questions.create') }}" class="btn btn-primary">
+      ＋ 新增題目
+    </a>
+  </div>
+
+  @php
+    $typeLabels = [
+      'recall' => '回想',
+      'fill' => '填空',
+      'choice' => '單選',
+    ];
+  @endphp
+
+  @forelse ($questions as $question)
+    <div class="card mb-3">
+      <div class="card-body">
+        <h5 class="card-title">
+          {{ \Illuminate\Support\Str::limit($question->question_text, 80) }}
+        </h5>
+
+        <p class="text-muted small mb-2">
+          題型：{{ $typeLabels[$question->question_type] ?? $question->question_type }}
+          <span class="ms-2">複習程度：{{ $question->review_level }}</span>
+        </p>
+
+        <p class="text-muted small mb-2">
+          關聯筆記：{{ $question->note?->title ?? '（未找到筆記）' }}
+          <span class="ms-2">建立時間：{{ $question->created_at?->format('Y-m-d') }}</span>
+        </p>
+
+        <div class="mt-3">
+          <a href="{{ route('questions.edit', $question) }}" class="btn btn-sm btn-outline-secondary">
+            編輯
+          </a>
+
+          <form action="{{ route('questions.destroy', $question) }}"
+                method="POST"
+                class="d-inline">
+            @csrf
+            @method('DELETE')
+            <button class="btn btn-sm btn-outline-danger"
+                    onclick="return confirm('確定要刪除？')">
+              刪除
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  @empty
+    <p class="text-muted">目前沒有任何題目</p>
+  @endforelse
+
+</div>
+@endsection

--- a/resources/views/review/show.blade.php
+++ b/resources/views/review/show.blade.php
@@ -1,0 +1,74 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h3>複習模式</h3>
+    <a href="{{ route('review.show') }}" class="btn btn-outline-primary btn-sm">換一題</a>
+  </div>
+
+  @if (!$question)
+    <div class="alert alert-warning">目前沒有可複習的題目。</div>
+    <a href="{{ route('questions.create') }}" class="btn btn-primary">前往新增題目</a>
+  @else
+    @php
+      $typeLabels = [
+        'recall' => '回想',
+        'fill' => '填空',
+        'choice' => '單選',
+      ];
+    @endphp
+
+    <div class="card">
+      <div class="card-body">
+        <p class="text-muted small">
+          題型：{{ $typeLabels[$question->question_type] ?? $question->question_type }}
+        </p>
+
+        <h5 class="card-title">{{ $question->question_text }}</h5>
+
+        @if ($question->question_type === 'choice' && $question->choices)
+          <ul class="list-group list-group-flush mb-3">
+            @foreach ($question->choices as $choice)
+              <li class="list-group-item">{{ $choice }}</li>
+            @endforeach
+          </ul>
+        @endif
+
+        <button class="btn btn-outline-secondary" type="button" data-action="toggle-answer">
+          顯示答案
+        </button>
+
+        <div class="mt-3" data-answer-block style="display: none;">
+          <div class="card border-light">
+            <div class="card-body">
+              <p><strong>正解：</strong>{{ $question->answer_text }}</p>
+
+              @if ($question->explanation)
+                <p><strong>補充：</strong>{{ $question->explanation }}</p>
+              @endif
+
+              <p class="mb-0"><strong>複習程度：</strong>{{ $question->review_level }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  @endif
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const button = document.querySelector('[data-action="toggle-answer"]');
+    const answerBlock = document.querySelector('[data-answer-block]');
+
+    if (!button || !answerBlock) return;
+
+    button.addEventListener('click', () => {
+      const isHidden = answerBlock.style.display === 'none';
+      answerBlock.style.display = isHidden ? 'block' : 'none';
+      button.textContent = isHidden ? '隱藏答案' : '顯示答案';
+    });
+  });
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\NoteController;
+use App\Http\Controllers\QuestionController;
+use App\Http\Controllers\ReviewController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -41,4 +43,13 @@ Route::middleware('supabase.auth')->group(function () {
     Route::get('/notes/{note}/edit', [NoteController::class, 'edit'])->name('notes.edit');
     Route::put('/notes/{note}', [NoteController::class, 'update'])->name('notes.update');
     Route::delete('/notes/{note}', [NoteController::class, 'destroy'])->name('notes.destroy');
+
+    Route::get('/questions', [QuestionController::class, 'index'])->name('questions.index');
+    Route::get('/questions/create', [QuestionController::class, 'create'])->name('questions.create');
+    Route::post('/questions', [QuestionController::class, 'store'])->name('questions.store');
+    Route::get('/questions/{question}/edit', [QuestionController::class, 'edit'])->name('questions.edit');
+    Route::put('/questions/{question}', [QuestionController::class, 'update'])->name('questions.update');
+    Route::delete('/questions/{question}', [QuestionController::class, 'destroy'])->name('questions.destroy');
+
+    Route::get('/review', [ReviewController::class, 'show'])->name('review.show');
 });


### PR DESCRIPTION
### Motivation
- Implement the v0.2 feature to turn notes into reviewable `questions` and allow users to set a subjective `review_level` for weighting in future sampling. 
- Provide a minimal manual review flow that presents one random question and reveals the answer on demand. 
- Keep the scope MVP-focused (no SRS, no AI, no automatic adjustments) and enforce per-user isolation for questions.

### Description
- Add `questions` table migration (`database/migrations/2026_01_11_000000_create_questions_table.php`) and `Question` model with `choices` cast and `fillable` fields. 
- Implement `QuestionController` with full CRUD, `normalizeChoices` and `sanitizeReviewLevel` helpers, and `ReviewController` that selects a random per-user question. 
- Add views for question management and review (`resources/views/questions/*`, `resources/views/review/show.blade.php`), update the app layout (`resources/views/layouts/app.blade.php`), routes (`routes/web.php`), and client JS (`resources/js/app.js`) to toggle form blocks by type. 
- Enforce access checks so `user_id` must match `session('supabase_user.id')` and ensure `note_id` belongs to the same user before create/update/delete.

### Testing
- Attempted to start the application with `php artisan serve` but it failed because `vendor/autoload.php` was missing, so the app could not be run in this environment. 
- No automated unit or feature tests were executed in this run. 
- Database migration file for `questions` was created but migrations were not applied here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696312f5b4d48323af416773ac3b277e)